### PR TITLE
Use POST on /auth/validateToken

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -88,7 +88,7 @@ impl Client {
     }
 
     pub(crate) fn check_auth(&self) -> bool {
-        match self.get("/auth/validateToken").call() {
+        match self.post("/auth/validateToken").call() {
             Ok(response) => response.status() == 200,
             Err(_) => false,
         }


### PR DESCRIPTION
As indicated in [the docs](https://immich.app/docs/api/validate-access-token/), the validateToken endpoint should be queried with a POST request (and not GET).